### PR TITLE
Fix broken header

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -21,8 +21,8 @@
   </head>
   <body>
     <header class="page-header" role="banner">
-      <a href="/" class="btn">Home</a>
       <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
+      <a href="/" class="btn">Home</a>
     </header>
 
     <main id="content" class="main-content" role="main">

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -6,7 +6,7 @@ header.page-header {
     background-color: #000;
     background-image: url('/assets/images/background.png');
     background-size: cover;
-    height: 540px;
+    min-height: 540px;
     width: 100%;
 
     z-index:-1;

--- a/assets/css/page.scss
+++ b/assets/css/page.scss
@@ -6,7 +6,7 @@ header.page-header {
     background-color: #000;
     background-image: url('/assets/images/background.png');
     background-size: cover;
-    height: 225px;
+    min-height: 225px;
     width: 100%;
     z-index:-1;
     color: #fff;


### PR DESCRIPTION
This PR fixes the Header layout and overflow
* Header at `home` and `page` should follow the same layout but the current position of Heading and Link is reversed.

|  Home  |  Page (used at [/contact](https://jpmorganchase.github.io/contact) and [/project](https://jpmorganchase.github.io/project))  |
|---|---|
| ![Screenshot from 2020-06-20 21-01-12](https://user-images.githubusercontent.com/31537546/85205543-960a8100-b339-11ea-8e96-0a7f38b8a677.png) | ![Screenshot from 2020-06-20 21-01-37](https://user-images.githubusercontent.com/31537546/85205547-999e0800-b339-11ea-8159-7536ef35f5ea.png) |

* At a smaller screen size, There is an overflow of text. It can be solved by using `min-height` instead of `height`

| Before | After |
|---|---|
| ![Screenshot from 2020-06-20 21-02-42](https://user-images.githubusercontent.com/31537546/85205651-4f695680-b33a-11ea-880a-1550e51e8e2c.png) | ![Screenshot from 2020-06-20 21-03-44](https://user-images.githubusercontent.com/31537546/85205655-542e0a80-b33a-11ea-8a97-33506e66a026.png)  |