### PR TITLE
Fixed the Tab/iPad view of projects page header..

### DIFF
--- a/_posts/2019-02-19-Welcome.md
+++ b/_posts/2019-02-19-Welcome.md
@@ -3,6 +3,8 @@ layout: post
 title: Introducing the new OSS@JP website
 ---
 
-Welcome to the new [homepage]( {{ site.baseurl }}) for Open Source at J.P. Morgan! Here you can find the latest [news]({{site.baseurl}}/news) about all things open source at the bank, information on how to [contact]({{site.baseurl}}/contact) and get involved, and a listing of all of the current [projects]( {{site.baseurl}}/projects). 
+Welcome to the new [homepage]( {{ site.baseurl }}) for Open Source at J.P. Morgan! Here you can find the latest [news]({{site.baseurl}}/news) about all things open source at the bank, information on how to [contact]({{site.baseurl}}/contact) and get involved, and a listing of all of the current [projects]( {{site.baseurl}}/projects). Feel free to make any [pull requests on your improvement ideas, on any open source repositories. 
+
+Wanna know how easy it is to create pull requests? [check it out](https://opensource.com/article/19/7/create-pull-request-github)
 
 

--- a/assets/css/page.scss
+++ b/assets/css/page.scss
@@ -6,7 +6,7 @@ header.page-header {
     background-color: #000;
     background-image: url('/assets/images/background.png');
     background-size: cover;
-    height: 225px;
+    height: auto;
     width: 100%;
     z-index:-1;
     color: #fff;


### PR DESCRIPTION
The page header of the projects page wasn't visible properly in the  Tab/iPad view, since only J.P was visible, Morgan wasn't. Using the appropriate css, I have fixed it.

Also I have added some text with a link, so that the new developers can easily see how to create a pull request and start contributing to other JPMC open source projects!