### PR TITLE
remove header height property from page.scss for media screen responsiveness

### DIFF
--- a/assets/css/page.scss
+++ b/assets/css/page.scss
@@ -6,7 +6,6 @@ header.page-header {
     background-color: #000;
     background-image: url('/assets/images/background.png');
     background-size: cover;
-    height: 225px;
     width: 100%;
     z-index:-1;
     color: #fff;


### PR DESCRIPTION
## Description
Remove header height property from page.scss

## Motivation and Context
Removing height constraint frees responsiveness and prevents white header text from overflowing into white background

## How Has This Been Tested?
End-to-end in major browsers: chrome, firefox, safari

## Screenshots (if appropriate):
![rm-header-height--joseph-p-pasaoa](https://user-images.githubusercontent.com/52214348/91237142-d9051e00-e707-11ea-9db1-5f381a52669b.gif)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings